### PR TITLE
Remove vendor_qcom_opensource_dataservices from cm.dependencies

### DIFF
--- a/cm.dependencies
+++ b/cm.dependencies
@@ -10,9 +10,5 @@
   {
     "repository": "android_external_sony_boringssl-compat",
     "target_path": "external/sony/boringssl-compat"
-  },
-  {
-    "repository": "android_vendor_qcom_opensource_dataservices",
-    "target_path": "vendor/qcom/opensource/dataservices"
   }
 ]


### PR DESCRIPTION
To prevent duplicating paths

Change-Id: I081a164987e9c7e316db7a8f933dc56bbe97949d