### PR TITLE
sepolicy: rmt_storage needs dac_override

### DIFF
--- a/sepolicy/rmt_storage.te
+++ b/sepolicy/rmt_storage.te
@@ -1,1 +1,2 @@
 allow rmt_storage ssd_device:blk_file rw_file_perms;
+allow rmt_storage self:capability dac_override;


### PR DESCRIPTION
* This is no longer in device/qcom/sepolicy

Change-Id: I60df3a789eaabe0d14db021d4e196e830704c5fb